### PR TITLE
[GCC 12] include missing array header

### DIFF
--- a/plugins/PCLPixelAlignmentRenderPlugin.cc
+++ b/plugins/PCLPixelAlignmentRenderPlugin.cc
@@ -12,6 +12,7 @@
 #include "TList.h"
 #include "TLine.h"
 #include <cassert>
+#include <array>
 
 class PCLPixelAlignmentRenderPlugin : public DQMRenderPlugin {
   std::array<double, 6> sigCut_;

--- a/plugins/RPCRenderPlugin.cc
+++ b/plugins/RPCRenderPlugin.cc
@@ -6,6 +6,7 @@
 #include "TColor.h"
 #include <iostream>
 #include <cassert>
+#include <array>
 #include "TLine.h"
 #include "TText.h"
 #include "TPaletteAxis.h"


### PR DESCRIPTION
This should fix the build errors like [a] for `GCC 12`

[a]
```
plugins/PCLPixelAlignmentRenderPlugin.cc:17:25: error: field 'sigCut_' has incomplete type 'std::array<double, 6>'
   17 |   std::array<double, 6> sigCut_;
      |                         ^~~~~~~
In file included from gcc/12.1.1-bf4aef5069fdf6bb6f77f897bcc8a6ae/include/c++/12.1.1/bits/unique_ptr.h:36,
                 from gcc/12.1.1-bf4aef5069fdf6bb6f77f897bcc8a6ae/include/c++/12.1.1/memory:76,
                 from root/6.24.07-a01fc23f50ffb43757a1073893e74c2c/include/ROOT/TypeTraits.hxx:15,
                 from root/6.24.07-a01fc23f50ffb43757a1073893e74c2c/include/TString.h:30,
                 from root/6.24.07-a01fc23f50ffb43757a1073893e74c2c/include/TCollection.h:29,
                 from root/6.24.07-a01fc23f50ffb43757a1073893e74c2c/include/TSeqCollection.h:25,
                 from root/6.24.07-a01fc23f50ffb43757a1073893e74c2c/include/TList.h:25,
                 from root/6.24.07-a01fc23f50ffb43757a1073893e74c2c/include/TQObject.h:40,
                 from root/6.24.07-a01fc23f50ffb43757a1073893e74c2c/include/TVirtualPad.h:30,
                 from root/6.24.07-a01fc23f50ffb43757a1073893e74c2c/include/TPad.h:15,
                 from root/6.24.07-a01fc23f50ffb43757a1073893e74c2c/include/TCanvas.h:15,
                 from plugins/PCLPixelAlignmentRenderPlugin.cc:3:
gcc/12.1.1-bf4aef5069fdf6bb6f77f897bcc8a6ae/include/c++/12.1.1/tuple:1595:45: note: declaration of 'struct std::array<double, 6>'
 1595 |   template<typename _Tp, size_t _Nm> struct array;
```